### PR TITLE
fix(BUG-003): handle malformed LLM response in hypothesis_generator

### DIFF
--- a/backend/agents/hypothesis_generator.py
+++ b/backend/agents/hypothesis_generator.py
@@ -64,10 +64,17 @@ def hypothesis_generator(state: AutoResearchState) -> dict[str, Any]:
         messages=[{"role": "user", "content": user_prompt}],
     )
 
-    raw = extract_json(extract_text(response))
-    hypothesis = raw["hypothesis"]
-    incremental_delta = raw.get("incremental_delta", "")
-    mentioned = raw.get("mentioned_entities", [])
+    text = extract_text(response)
+    try:
+        raw = extract_json(text)
+        hypothesis = raw["hypothesis"]
+        incremental_delta = raw.get("incremental_delta", "")
+        mentioned = raw.get("mentioned_entities", [])
+    except (ValueError, KeyError):
+        logger.warning("hypothesis_generator: JSON parsing failed, using raw response as hypothesis")
+        hypothesis = text.strip()
+        incremental_delta = ""
+        mentioned = []
 
     entity_names = {e["canonical_name"].lower() for e in kg_entities}
     for alias_list in (e.get("aliases", []) for e in kg_entities):

--- a/tests/test_hypothesis_generator.py
+++ b/tests/test_hypothesis_generator.py
@@ -151,3 +151,38 @@ def test_hypothesis_embedding_has_correct_length(mock_cls, mock_embed, mock_nove
     mock_cls.return_value = _make_mock_client()
     result = hypothesis_generator(BASE_STATE)
     assert len(result["hypothesis_embedding"]) == 384
+
+
+# ─── BUG-003 regression tests ─────────────────────────────────────────────────
+
+
+def _make_mock_client_raw_text(raw_text: str):
+    block = MagicMock()
+    block.text = raw_text
+    response = MagicMock()
+    response.content = [block]
+    client = MagicMock()
+    client.messages.create.return_value = response
+    return client
+
+
+@patch("backend.agents.hypothesis_generator._pgvector_novelty_check", return_value=(0.8, 0.2))
+@patch("backend.agents.hypothesis_generator.embed_single", return_value=[0.1] * 384)
+@patch("backend.agents.hypothesis_generator.anthropic.Anthropic")
+def test_malformed_json_does_not_crash(mock_cls, mock_embed, mock_novelty):
+    """BUG-003: hypothesis_generator must not crash when LLM returns invalid JSON."""
+    mock_cls.return_value = _make_mock_client_raw_text("This is not JSON at all.")
+    result = hypothesis_generator(BASE_STATE)
+    assert "hypothesis" in result
+    assert len(result["hypothesis"]) > 0
+
+
+@patch("backend.agents.hypothesis_generator._pgvector_novelty_check", return_value=(0.8, 0.2))
+@patch("backend.agents.hypothesis_generator.embed_single", return_value=[0.1] * 384)
+@patch("backend.agents.hypothesis_generator.anthropic.Anthropic")
+def test_missing_hypothesis_key_does_not_crash(mock_cls, mock_embed, mock_novelty):
+    """BUG-003: hypothesis_generator must not crash when JSON is valid but missing 'hypothesis' key."""
+    mock_cls.return_value = _make_mock_client({"incremental_delta": "some delta"})
+    result = hypothesis_generator(BASE_STATE)
+    assert "hypothesis" in result
+    assert len(result["hypothesis"]) > 0


### PR DESCRIPTION
## Summary
  - Wraps `extract_json` + `raw["hypothesis"]` in try/except in `hypothesis_generator.py`
  - Adds 2 regression tests in `tests/test_hypothesis_generator.py`

  ## Root cause
  If the LLM returns invalid JSON, `extract_json` raises `ValueError`. If JSON is valid but missing the `"hypothesis"` key, `raw["hypothesis"]` 
  raises `KeyError`. Neither was caught, crashing the pipeline.
  
  ## Test plan
  - [x] `test_malformed_json_does_not_crash` passes
  - [x] `test_missing_hypothesis_key_does_not_crash` passes
  - [x] All 13 tests in `tests/test_hypothesis_generator.py` pass

  Fixes #29