### PR TITLE
Wire HITL gates, per-run overrides, and artifact downloads into UI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,41 @@
-node_modules
-dist
-.git
+# Python
+venv/
+.venv/
+**/__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.python-version
+*.egg-info/
+
+# Node / frontend build outputs
+node_modules/
+dist/
+.vite/
+
+# Local caches and runtime artifacts
+.cache/
+.runtime/
+
+# Editor / OS
+.idea/
+.vscode/
+.DS_Store
+
+# Git / docs / secrets / large outputs
+.git/
 .gitignore
+.gitattributes
+.github/
 .env
-.cache
-.runtime
+.env.*
+!.env.example
 *.md
+papers/
+tests/
+
+# Docker meta (the daemon doesn't need these copied in)
+docker-compose.yml
+Dockerfile
+Dockerfile.*
+.dockerignore

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ env/
 # Pipeline caches (host-side artifacts pre-fetched for the network=none sandbox)
 .cache/
 
+# Docker sandbox runtime (owned by the docker daemon — never committable)
+.runtime/
+
 # Local pipeline outputs (PDFs, .tex, metrics, debug logs)
 artifacts/
 runs/

--- a/backend/agents/academic_writer.py
+++ b/backend/agents/academic_writer.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import anthropic
 
-from backend.config import MODELS
+from backend.utils.run_overrides import effective_model_for
 from backend.state import AutoResearchState
 from backend.utils.llm_utils import extract_json, extract_text
 
@@ -98,7 +98,7 @@ def _first_pass(state: AutoResearchState) -> dict[str, Any]:
     )
 
     response = client.messages.create(
-        model=MODELS.academic_writer,
+        model=effective_model_for("academic_writer"),
         max_tokens=16384,
         system=WRITER_SYSTEM_PROMPT,
         messages=[{"role": "user", "content": user_prompt}],
@@ -139,7 +139,7 @@ def _revision_pass(state: AutoResearchState) -> dict[str, Any]:
     )
 
     response = client.messages.create(
-        model=MODELS.academic_writer,
+        model=effective_model_for("academic_writer"),
         max_tokens=16384,
         system=REVISION_SYSTEM_PROMPT,
         messages=[{"role": "user", "content": user_prompt}],

--- a/backend/agents/arxiv_retriever.py
+++ b/backend/agents/arxiv_retriever.py
@@ -20,6 +20,7 @@ import arxiv
 from sklearn.feature_extraction.text import TfidfVectorizer
 
 from backend.config import THRESHOLDS
+from backend.utils.run_overrides import effective_arxiv_results_per_round
 from backend.state import AutoResearchState
 from backend.utils.embeddings import embed_single
 from backend.utils.supabase_client import get_supabase
@@ -39,7 +40,7 @@ def arxiv_retriever(state: AutoResearchState) -> dict[str, Any]:
     else:
         query = _build_refined_query(state)
 
-    max_results = THRESHOLDS.arxiv_results_per_round
+    max_results = effective_arxiv_results_per_round()
     new_papers: list[dict[str, Any]] = []
 
     search = arxiv.Search(

--- a/backend/agents/critique_panel.py
+++ b/backend/agents/critique_panel.py
@@ -17,7 +17,7 @@ from typing import Any
 
 import anthropic
 
-from backend.config import MODELS
+from backend.utils.run_overrides import effective_model_for
 from backend.state import AutoResearchState, DebateEntry
 from backend.utils.llm_utils import extract_json, extract_text
 
@@ -113,15 +113,15 @@ def critique_panel(state: AutoResearchState) -> dict[str, Any]:
 
     # ── Phase 1: Independent critique ────────────────────────────────────
     agents = [
-        ("fact_checker", MODELS.critique_fact_checker, FACT_CHECKER_PROMPT, {
+        ("fact_checker", effective_model_for("critique_fact_checker"), FACT_CHECKER_PROMPT, {
             "kg_entities": json.dumps(kg_entities[:30], indent=2),
             "kg_edges": json.dumps(kg_edges[:50], indent=2),
             "claim_ledger": json.dumps(claim_ledger, indent=2),
         }),
-        ("methodologist", MODELS.critique_methodologist, METHODOLOGIST_PROMPT, {
+        ("methodologist", effective_model_for("critique_methodologist"), METHODOLOGIST_PROMPT, {
             "metrics": json.dumps(metrics, indent=2),
         }),
-        ("formatter", MODELS.critique_formatter, FORMATTER_PROMPT, {}),
+        ("formatter", effective_model_for("critique_formatter"), FORMATTER_PROMPT, {}),
     ]
 
     all_critiques: dict[str, list[dict[str, Any]]] = {}
@@ -165,7 +165,7 @@ def critique_panel(state: AutoResearchState) -> dict[str, Any]:
 
         try:
             response = client.messages.create(
-                model=MODELS.critique_methodologist,
+                model=effective_model_for("critique_methodologist"),
                 max_tokens=2048,
                 messages=[{"role": "user", "content": prompt}],
             )
@@ -203,7 +203,7 @@ def critique_panel(state: AutoResearchState) -> dict[str, Any]:
 
         try:
             response = client.messages.create(
-                model=MODELS.critique_methodologist,
+                model=effective_model_for("critique_methodologist"),
                 max_tokens=1024,
                 messages=[{"role": "user", "content": prompt}],
             )

--- a/backend/agents/executor.py
+++ b/backend/agents/executor.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from backend.config import THRESHOLDS
+from backend.utils.run_overrides import effective_max_code_retries
 from backend.state import AutoResearchState
 from backend.utils.docker_utils import run_sandboxed
 
@@ -37,10 +37,10 @@ def executor(state: AutoResearchState) -> dict[str, Any]:
         }
 
     retry_count += 1
-    logger.warning("Execution failed (attempt %d/%d)",
-                    retry_count, THRESHOLDS.max_code_retries)
+    max_retries = effective_max_code_retries()
+    logger.warning("Execution failed (attempt %d/%d)", retry_count, max_retries)
 
-    if retry_count >= THRESHOLDS.max_code_retries:
+    if retry_count >= max_retries:
         return {
             "execution_success": False,
             "execution_logs": logs,

--- a/backend/agents/experiment_designer.py
+++ b/backend/agents/experiment_designer.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import anthropic
 
-from backend.config import MODELS
+from backend.utils.run_overrides import effective_model_for
 from backend.state import AutoResearchState, ExperimentSpec
 from backend.utils.llm_utils import extract_json, extract_text
 
@@ -78,7 +78,7 @@ def experiment_designer(state: AutoResearchState) -> dict[str, Any]:
     )
 
     response = client.messages.create(
-        model=MODELS.experiment_designer,
+        model=effective_model_for("experiment_designer"),
         max_tokens=2048,
         system=DESIGNER_SYSTEM_PROMPT,
         messages=[{"role": "user", "content": user_prompt}],

--- a/backend/agents/hitl_experiment_gate.py
+++ b/backend/agents/hitl_experiment_gate.py
@@ -14,6 +14,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from backend.state import AutoResearchState
+from backend.utils import hitl_bridge
 
 console = Console()
 
@@ -23,6 +24,37 @@ def _auto_approve_enabled() -> bool:
         "1",
         "true",
         "yes",
+    }
+
+
+def _build_review_payload(state: AutoResearchState) -> dict[str, Any]:
+    """Serialise the same review surface the CLI prints, for the UI bridge."""
+    spec = state.get("experiment_spec") or {}
+    kg_entities = state.get("kg_entities", [])
+    kg_edges = state.get("kg_edges", [])
+    entity_map = {e["id"]: e["canonical_name"] for e in kg_entities}
+
+    contested = [e for e in kg_edges if e.get("polarity") in ("supports", "contradicts")]
+    return {
+        "hypothesis": state.get("hypothesis", ""),
+        "incremental_delta": state.get("incremental_delta", ""),
+        "spec": {
+            "independent_var": spec.get("independent_var", ""),
+            "dependent_var": spec.get("dependent_var", ""),
+            "control_description": spec.get("control_description", ""),
+            "dataset_id": spec.get("dataset_id", ""),
+            "evaluation_metrics": list(spec.get("evaluation_metrics", [])),
+            "expected_outcome": spec.get("expected_outcome", ""),
+        },
+        "kg_edges": [
+            {
+                "source": entity_map.get(e["source_id"], "?"),
+                "relation": e["relation"],
+                "target": entity_map.get(e["target_id"], "?"),
+                "polarity": e["polarity"],
+            }
+            for e in contested[:8]
+        ],
     }
 
 
@@ -78,6 +110,29 @@ def hitl_experiment_gate(state: AutoResearchState) -> dict[str, Any]:
             "pipeline_status": "approved_experiment",
         }
 
+    # API mode: hand the review payload to the UI bridge and wait.
+    if hitl_bridge.current_mode() == "api" and hitl_bridge.get_run_id():
+        decision = hitl_bridge.await_decision(
+            gate_id="experiment",
+            payload=_build_review_payload(state),
+        )
+        if decision["action"] == "approve":
+            return {
+                "hitl_experiment_approved": True,
+                "pipeline_status": "approved_experiment",
+            }
+        reason = (decision.get("reason") or "").strip().lower()
+        if reason == "abort":
+            return {
+                "hitl_experiment_approved": False,
+                "pipeline_status": "failed_hitl_rejected",
+            }
+        return {
+            "hitl_experiment_approved": False,
+            "pipeline_status": "redesign_experiment",
+        }
+
+    # CLI mode (terminal stdin).
     console.print("\n[bold]Enter [green]approve[/green] or [red]reject[/red] (or [red]abort[/red]):[/bold]")
     user_input = input("> ").strip().lower()
 

--- a/backend/agents/hitl_gate.py
+++ b/backend/agents/hitl_gate.py
@@ -17,6 +17,7 @@ from rich.text import Text
 
 from backend.config import THRESHOLDS
 from backend.state import AutoResearchState
+from backend.utils import hitl_bridge
 
 console = Console()
 
@@ -26,6 +27,45 @@ def _auto_approve_enabled() -> bool:
         "1",
         "true",
         "yes",
+    }
+
+
+def _build_review_payload(state: AutoResearchState) -> dict[str, Any]:
+    """Serialise the same review surface the CLI prints, for the UI bridge."""
+    kg_entities = state.get("kg_entities", [])
+    kg_edges = state.get("kg_edges", [])
+    papers = state.get("arxiv_papers_full_text", [])
+    entity_map = {e["id"]: e["canonical_name"] for e in kg_entities}
+
+    novelty = float(state.get("novelty_score", 0.0))
+    prior_art = float(state.get("prior_art_similarity_score", 0.0))
+    return {
+        "hypothesis": state.get("hypothesis", ""),
+        "incremental_delta": state.get("incremental_delta", ""),
+        "novelty": {
+            "score": novelty,
+            "threshold": THRESHOLDS.novelty_threshold,
+            "pass": novelty >= THRESHOLDS.novelty_threshold,
+        },
+        "prior_art": {
+            "similarity": prior_art,
+            "ceiling": THRESHOLDS.prior_art_ceiling,
+            "pass": prior_art < THRESHOLDS.prior_art_ceiling,
+        },
+        "kg_triples": [
+            {
+                "source": entity_map.get(e["source_id"], "?"),
+                "relation": e["relation"],
+                "target": entity_map.get(e["target_id"], "?"),
+                "polarity": e["polarity"],
+            }
+            for e in kg_edges[:10]
+        ],
+        "papers": [
+            {"arxiv_id": p.get("arxiv_id", "?"), "title": p.get("title", "?")}
+            for p in papers[:8]
+        ],
+        "paper_total": len(papers),
     }
 
 
@@ -116,6 +156,24 @@ def hitl_gate(state: AutoResearchState) -> dict[str, Any]:
             "pipeline_status": "approved_hypothesis",
         }
 
+    # API mode: hand the review payload to the UI bridge and wait.
+    if hitl_bridge.current_mode() == "api" and hitl_bridge.get_run_id():
+        decision = hitl_bridge.await_decision(
+            gate_id="hypothesis",
+            payload=_build_review_payload(state),
+        )
+        if decision["action"] == "approve":
+            return {
+                "hitl_approved": True,
+                "pipeline_status": "approved_hypothesis",
+            }
+        return {
+            "hitl_approved": False,
+            "hitl_rejection_reason": decision.get("reason") or "No reason provided",
+            "pipeline_status": "failed_hitl_rejected",
+        }
+
+    # CLI mode (terminal stdin).
     console.print("\n[bold]Enter [green]approve[/green] or [red]reject <reason>[/red]:[/bold]")
     user_input = input("> ").strip()
 

--- a/backend/agents/hypothesis_generator.py
+++ b/backend/agents/hypothesis_generator.py
@@ -12,7 +12,8 @@ from typing import Any
 
 import anthropic
 
-from backend.config import MODELS, THRESHOLDS
+from backend.config import THRESHOLDS
+from backend.utils.run_overrides import effective_model_for
 from backend.state import AutoResearchState
 from backend.utils.embeddings import embed_single
 from backend.utils.llm_utils import extract_json, extract_text
@@ -58,7 +59,7 @@ def hypothesis_generator(state: AutoResearchState) -> dict[str, Any]:
     )
 
     response = client.messages.create(
-        model=MODELS.hypothesis_generator,
+        model=effective_model_for("hypothesis_generator"),
         max_tokens=2048,
         system=HYPOTHESIS_SYSTEM_PROMPT,
         messages=[{"role": "user", "content": user_prompt}],

--- a/backend/agents/kg_extractor.py
+++ b/backend/agents/kg_extractor.py
@@ -15,7 +15,7 @@ from typing import Any
 
 import anthropic
 
-from backend.config import MODELS
+from backend.utils.run_overrides import effective_model_for
 from backend.state import AutoResearchState, KGEdge, KGEntity
 from backend.utils.llm_utils import extract_json, extract_text
 from backend.utils.kg_utils import (
@@ -86,7 +86,7 @@ def kg_extractor(state: AutoResearchState) -> dict[str, Any]:
 
         try:
             response = client.messages.create(
-                model=MODELS.kg_extractor,
+                model=effective_model_for("kg_extractor"),
                 max_tokens=4096,
                 system=EXTRACTION_SYSTEM_PROMPT,
                 messages=[{"role": "user", "content": paper_text}],

--- a/backend/agents/latex_compiler.py
+++ b/backend/agents/latex_compiler.py
@@ -14,7 +14,8 @@ from typing import Any
 
 import anthropic
 
-from backend.config import MODELS, THRESHOLDS
+from backend.config import THRESHOLDS
+from backend.utils.run_overrides import effective_model_for
 from backend.state import AutoResearchState
 from backend.utils.llm_utils import extract_json, extract_text
 from backend.utils.latex_utils import (
@@ -116,7 +117,7 @@ def _get_repair_patch(error: Any) -> dict[str, Any] | None:
 
     try:
         response = client.messages.create(
-            model=MODELS.latex_repair,
+            model=effective_model_for("latex_repair"),
             max_tokens=512,
             system=REPAIR_SYSTEM_PROMPT,
             messages=[{"role": "user", "content": error_context}],

--- a/backend/agents/ml_coder.py
+++ b/backend/agents/ml_coder.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import anthropic
 
-from backend.config import MODELS
+from backend.utils.run_overrides import effective_model_for
 from backend.state import AutoResearchState
 
 logger = logging.getLogger(__name__)
@@ -94,7 +94,7 @@ def ml_coder(state: AutoResearchState) -> dict[str, Any]:
         )
 
     response = client.messages.create(
-        model=MODELS.ml_coder,
+        model=effective_model_for("ml_coder"),
         max_tokens=8192,
         system=system,
         messages=[{"role": "user", "content": user_prompt}],

--- a/backend/api.py
+++ b/backend/api.py
@@ -15,11 +15,16 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from typing import Any, Literal
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Response
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
+from backend.config import ARTIFACTS_BUCKET
+from backend.utils.supabase_client import get_supabase
+
 from backend.graph import run_pipeline
+from backend.utils import hitl_bridge, run_overrides
+from backend.utils.run_overrides import RunOverrides
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +33,11 @@ RunStatus = Literal["queued", "running", "success", "failed"]
 
 class CreateRunRequest(BaseModel):
     topic: str = Field(..., min_length=3, max_length=500)
+    # Optional per-run tunables. ``None`` falls through to the defaults in
+    # ``backend.config`` — sending nothing here keeps the original behaviour.
+    max_code_retries: int | None = Field(default=None, ge=0, le=10)
+    arxiv_results_per_round: int | None = Field(default=None, ge=1, le=50)
+    model_override: str | None = Field(default=None, max_length=120)
 
 
 class RunRecord(BaseModel):
@@ -38,6 +48,7 @@ class RunRecord(BaseModel):
     updated_at: str
     result: dict[str, Any] | None = None
     error: str | None = None
+    overrides: dict[str, Any] | None = None
 
 
 app = FastAPI(title="Auto-Mini-Claw API", version="0.1.0")
@@ -74,16 +85,21 @@ def _get(run_id: str) -> RunRecord | None:
         return _runs.get(run_id)
 
 
-def _execute_run(run_id: str, topic: str) -> None:
+def _execute_run(run_id: str, topic: str, overrides: RunOverrides | None) -> None:
     record = _get(run_id)
     if not record:
         return
 
     _save(record.model_copy(update={"status": "running", "updated_at": _now()}))
-    logger.info("API run started client_run_id=%s topic=%r", run_id, topic)
+    logger.info(
+        "API run started client_run_id=%s topic=%r overrides=%s",
+        run_id, topic, overrides,
+    )
 
+    hitl_bridge.bind_run_id(run_id)
+    run_overrides.bind(overrides)
     try:
-        result = dict(run_pipeline(topic))
+        result = dict(run_pipeline(topic, run_id=run_id))
         pipeline_status = str(result.get("pipeline_status", "unknown"))
         status: RunStatus = "success" if pipeline_status == "success" else "failed"
         _save(
@@ -108,6 +124,9 @@ def _execute_run(run_id: str, topic: str) -> None:
                 }
             )
         )
+    finally:
+        hitl_bridge.clear_run_id()
+        run_overrides.clear()
 
 
 @app.get("/api/health")
@@ -118,15 +137,35 @@ def health() -> dict[str, str]:
 @app.post("/api/runs", response_model=RunRecord, status_code=202)
 def create_run(payload: CreateRunRequest) -> RunRecord:
     run_id = str(uuid.uuid4())
+    overrides: RunOverrides | None = None
+    if (
+        payload.max_code_retries is not None
+        or payload.arxiv_results_per_round is not None
+        or payload.model_override
+    ):
+        overrides = RunOverrides(
+            max_code_retries=payload.max_code_retries,
+            arxiv_results_per_round=payload.arxiv_results_per_round,
+            model_override=(payload.model_override or None),
+        )
     record = RunRecord(
         client_run_id=run_id,
         topic=payload.topic.strip(),
         status="queued",
         created_at=_now(),
         updated_at=_now(),
+        overrides=(
+            {
+                "max_code_retries": overrides.max_code_retries,
+                "arxiv_results_per_round": overrides.arxiv_results_per_round,
+                "model_override": overrides.model_override,
+            }
+            if overrides
+            else None
+        ),
     )
     _save(record)
-    _executor.submit(_execute_run, run_id, record.topic)
+    _executor.submit(_execute_run, run_id, record.topic, overrides)
     return record
 
 
@@ -136,3 +175,116 @@ def get_run(run_id: str) -> RunRecord:
     if not record:
         raise HTTPException(status_code=404, detail="Run not found")
     return record
+
+
+# ─── HITL gate endpoints ─────────────────────────────────────────────────────
+class GateDecisionRequest(BaseModel):
+    gate_id: Literal["hypothesis", "experiment"]
+    action: Literal["approve", "reject"]
+    reason: str = Field(default="", max_length=2000)
+
+
+@app.get("/api/runs/{run_id}/pending-gate")
+def pending_gate(run_id: str) -> dict[str, Any]:
+    """Return the pending HITL gate payload for this run, or 204 if none."""
+    if _get(run_id) is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+    snapshot = hitl_bridge.peek_pending(run_id)
+    if snapshot is None:
+        # No gate currently waiting — the UI will poll again.
+        return {"pending": False}
+    return {"pending": True, **snapshot}
+
+
+# ─── Artifact download endpoints ─────────────────────────────────────────────
+# Whitelist of filenames the uploader produces. Used to reject path-traversal
+# attempts before we ever ask Supabase Storage for a blob.
+_ALLOWED_ARTIFACTS: frozenset[str] = frozenset({
+    "metrics.json",
+    "claim_ledger.json",
+    "debate_log.json",
+    "draft.tex",
+    "references.bib",
+    "python_code.py",
+    "execution_logs.txt",
+    "hypothesis.txt",
+    "experiment_spec.json",
+    "final_paper.pdf",
+    "failure_report.json",
+})
+
+_CONTENT_TYPES: dict[str, str] = {
+    ".json": "application/json",
+    ".pdf": "application/pdf",
+    ".tex": "text/x-tex",
+    ".bib": "text/x-bibtex",
+    ".py": "text/x-python",
+    ".txt": "text/plain",
+}
+
+
+@app.get("/api/runs/{run_id}/artifacts")
+def list_artifacts(run_id: str) -> dict[str, Any]:
+    """List the artifact filenames currently in Supabase Storage for this run.
+
+    Returns ``{"files": ["failure_report.json", ...]}`` ordered by name. The
+    UI uses this to decide which download buttons to render — a failed run
+    typically has the diagnostic set but no ``final_paper.pdf``.
+    """
+    if _get(run_id) is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+    sb = get_supabase()
+    try:
+        entries = sb.storage.from_(ARTIFACTS_BUCKET).list(run_id)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=502, detail=f"Storage list failed: {exc}") from exc
+    names = sorted(
+        e["name"] for e in entries
+        if e.get("name") and e["name"] in _ALLOWED_ARTIFACTS
+    )
+    return {"run_id": run_id, "files": names}
+
+
+@app.get("/api/runs/{run_id}/artifacts/{filename}")
+def download_artifact(run_id: str, filename: str) -> Response:
+    """Stream an individual artifact from Supabase Storage as a download."""
+    if filename not in _ALLOWED_ARTIFACTS:
+        raise HTTPException(status_code=400, detail=f"Filename {filename!r} not allowed")
+    if _get(run_id) is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+    sb = get_supabase()
+    try:
+        blob = sb.storage.from_(ARTIFACTS_BUCKET).download(f"{run_id}/{filename}")
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(
+            status_code=404,
+            detail=f"Artifact {filename!r} not found in storage for this run",
+        ) from exc
+    suffix = filename[filename.rfind("."):].lower() if "." in filename else ""
+    return Response(
+        content=blob,
+        media_type=_CONTENT_TYPES.get(suffix, "application/octet-stream"),
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@app.post("/api/runs/{run_id}/gate-decision")
+def gate_decision(run_id: str, payload: GateDecisionRequest) -> dict[str, Any]:
+    """Record the operator's approve/reject and release the pipeline thread."""
+    if _get(run_id) is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+    accepted = hitl_bridge.submit_decision(
+        run_id=run_id,
+        gate_id=payload.gate_id,
+        action=payload.action,
+        reason=payload.reason,
+    )
+    if not accepted:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"No pending {payload.gate_id!r} gate for this run — "
+                "the pipeline may have moved on already."
+            ),
+        )
+    return {"accepted": True}

--- a/backend/graph.py
+++ b/backend/graph.py
@@ -18,6 +18,7 @@ from langgraph.graph import END, START, StateGraph
 
 from backend import config
 from backend.config import THRESHOLDS
+from backend.utils.run_overrides import effective_max_code_retries
 from backend.state import AutoResearchState
 from backend.utils.artifact_uploader import (
     create_run,
@@ -85,7 +86,7 @@ def route_executor(state: AutoResearchState) -> str:
     """After Node 5: claim ledger / retry / fail."""
     if state.get("execution_success", False):
         return "claim_ledger_builder"
-    if state.get("code_retry_count", 0) < THRESHOLDS.max_code_retries:
+    if state.get("code_retry_count", 0) < effective_max_code_retries():
         return "ml_coder"
     return END
 
@@ -200,16 +201,21 @@ def get_graph() -> Any:
 # ─── Pipeline runner with artifact-upload finally hook ──────────────────────
 
 
-def run_pipeline(topic: str) -> AutoResearchState:
+def run_pipeline(topic: str, run_id: str | None = None) -> AutoResearchState:
     """End-to-end pipeline invocation.
 
-    Allocates a `run_id`, executes the LangGraph DAG, and uploads artifacts to
-    Supabase Storage on every terminal path (success OR failure OR crash) via
-    a `finally` block — per IMPLEMENTATION_GUIDE §4.4 (the simpler approach).
+    Allocates (or reuses) a ``run_id``, executes the LangGraph DAG, and uploads
+    artifacts to Supabase Storage on every terminal path (success OR failure
+    OR crash) via a ``finally`` block — per IMPLEMENTATION_GUIDE §4.4.
+
+    The API layer passes its client-facing UUID as ``run_id`` so that the same
+    id surfaces in the UI, in ``pipeline_runs.id``, and in the
+    ``artifacts/{run_id}/`` storage folder. CLI callers omit it and get a
+    freshly generated UUID.
     """
     config.assert_env_ready()
 
-    run_id = create_run(topic)
+    run_id = create_run(topic, run_id=run_id)
     logger.info("Starting pipeline run_id=%s topic=%r", run_id, topic)
 
     initial_state: AutoResearchState = {

--- a/backend/utils/artifact_uploader.py
+++ b/backend/utils/artifact_uploader.py
@@ -17,9 +17,15 @@ from backend.state import AutoResearchState
 from backend.utils.supabase_client import get_supabase
 
 
-def create_run(topic: str) -> str:
-    """Insert a new pipeline_runs row with status='running'. Returns run_id."""
-    run_id = str(uuid.uuid4())
+def create_run(topic: str, run_id: str | None = None) -> str:
+    """Insert a new pipeline_runs row with status='running'. Returns run_id.
+
+    If *run_id* is provided (typically by the FastAPI layer's
+    ``client_run_id``), use it as-is so the API id, the ``pipeline_runs.id``
+    row, and the ``artifacts/{run_id}/`` storage folder all share one UUID.
+    Otherwise generate a fresh one — preserves the CLI behaviour.
+    """
+    run_id = run_id or str(uuid.uuid4())
     sb = get_supabase()
     sb.table(PIPELINE_RUNS_TABLE).insert({
         "id": run_id,

--- a/backend/utils/hitl_bridge.py
+++ b/backend/utils/hitl_bridge.py
@@ -1,0 +1,147 @@
+"""Bridge between the LangGraph pipeline thread and the FastAPI request handler.
+
+When ``AUTO_MINI_CLAW_HITL_MODE=api`` the HITL nodes no longer call ``input()``
+on stdin. Instead they:
+
+1. Look up the current run's ``run_id`` from a thread-local set by the API.
+2. Publish the review payload (everything the CLI's Rich panels would have
+   shown) to ``_pending``.
+3. Block on a ``threading.Event`` until the API receives a POST and calls
+   :func:`submit_decision`, which writes the decision back into ``_pending``
+   and sets the event.
+
+The pipeline thread then reads the decision and returns control to LangGraph.
+The whole exchange is in-process, so it works fine for a single-worker
+deployment (which is what ``docker-compose.yml`` provisions).
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from typing import Any, Literal, TypedDict
+
+HITLMode = Literal["cli", "api"]
+
+
+def current_mode() -> HITLMode:
+    """Return ``"api"`` when the API has bound a run id, else ``"cli"``."""
+    raw = os.getenv("AUTO_MINI_CLAW_HITL_MODE", "cli").strip().lower()
+    return "api" if raw == "api" else "cli"
+
+
+# ─── Run-id binding (thread-local) ───────────────────────────────────────────
+_current = threading.local()
+
+
+def bind_run_id(run_id: str) -> None:
+    """Associate the calling thread with an API ``run_id``.
+
+    Called by ``backend.api._execute_run`` immediately before invoking
+    ``run_pipeline()`` so that any HITL gate inside the graph can publish its
+    review payload under the correct id.
+    """
+    _current.run_id = run_id
+
+
+def clear_run_id() -> None:
+    """Drop the thread-local binding (call in a ``finally`` block)."""
+    if hasattr(_current, "run_id"):
+        del _current.run_id
+
+
+def get_run_id() -> str | None:
+    return getattr(_current, "run_id", None)
+
+
+# ─── Pending-gate registry ───────────────────────────────────────────────────
+class PendingGate(TypedDict):
+    run_id: str
+    gate_id: Literal["hypothesis", "experiment"]
+    payload: dict[str, Any]
+    event: threading.Event
+    decision: dict[str, Any] | None
+
+
+_pending: dict[str, PendingGate] = {}
+_lock = threading.Lock()
+
+
+def await_decision(
+    gate_id: Literal["hypothesis", "experiment"],
+    payload: dict[str, Any],
+    timeout_seconds: float = 3600.0,
+) -> dict[str, Any]:
+    """Block the pipeline thread until the UI posts an approve/reject.
+
+    Raises ``RuntimeError`` if no run id is bound (i.e. the bridge was called
+    outside an API context) or if the wait times out.
+    """
+    run_id = get_run_id()
+    if run_id is None:
+        raise RuntimeError(
+            "hitl_bridge.await_decision called without a bound run_id — "
+            "this code path is only valid when invoked from the FastAPI "
+            "executor with AUTO_MINI_CLAW_HITL_MODE=api."
+        )
+
+    event = threading.Event()
+    entry: PendingGate = {
+        "run_id": run_id,
+        "gate_id": gate_id,
+        "payload": payload,
+        "event": event,
+        "decision": None,
+    }
+    with _lock:
+        _pending[run_id] = entry
+
+    try:
+        if not event.wait(timeout=timeout_seconds):
+            raise RuntimeError(
+                f"HITL gate {gate_id!r} timed out after {timeout_seconds}s "
+                f"waiting for a UI decision (run_id={run_id})"
+            )
+        decision = entry["decision"]
+        assert decision is not None  # set by submit_decision before event
+        return decision
+    finally:
+        with _lock:
+            _pending.pop(run_id, None)
+
+
+def peek_pending(run_id: str) -> dict[str, Any] | None:
+    """Return the pending-gate snapshot for ``run_id`` (or ``None``).
+
+    Used by ``GET /api/runs/{run_id}/pending-gate``. Returns a plain dict
+    safe to serialise (no ``threading.Event``).
+    """
+    with _lock:
+        entry = _pending.get(run_id)
+        if entry is None:
+            return None
+        return {
+            "run_id": entry["run_id"],
+            "gate_id": entry["gate_id"],
+            "payload": entry["payload"],
+        }
+
+
+def submit_decision(
+    run_id: str,
+    gate_id: Literal["hypothesis", "experiment"],
+    action: Literal["approve", "reject"],
+    reason: str = "",
+) -> bool:
+    """Record an approve/reject and release the waiting pipeline thread.
+
+    Returns ``True`` on success, ``False`` if no matching pending gate is
+    found (e.g. the UI raced ahead of the pipeline).
+    """
+    with _lock:
+        entry = _pending.get(run_id)
+        if entry is None or entry["gate_id"] != gate_id:
+            return False
+        entry["decision"] = {"action": action, "reason": reason}
+        entry["event"].set()
+    return True

--- a/backend/utils/kg_utils.py
+++ b/backend/utils/kg_utils.py
@@ -13,7 +13,8 @@ from typing import Any
 
 import anthropic
 
-from backend.config import MODELS, THRESHOLDS
+from backend.config import THRESHOLDS
+from backend.utils.run_overrides import effective_model_for
 from backend.state import KGEdge, KGEntity
 from backend.utils.embeddings import find_synonym_clusters
 from backend.utils.llm_utils import extract_json, extract_text
@@ -65,7 +66,7 @@ def _llm_pick_canonical(
         indent=2,
     )
     response = client.messages.create(
-        model=MODELS.kg_dedup,
+        model=effective_model_for("kg_dedup"),
         max_tokens=256,
         system=(
             "You are merging duplicate knowledge graph entities. "

--- a/backend/utils/run_overrides.py
+++ b/backend/utils/run_overrides.py
@@ -1,0 +1,88 @@
+"""Per-run overrides for the model assignments and tunable thresholds.
+
+The defaults in :mod:`backend.config` (``MODELS``, ``THRESHOLDS``) are frozen
+dataclasses that the agents import at module load time, so they cannot be
+mutated. When the API receives a request that wants to customise behaviour
+for a single run, we record the overrides in a thread-local registry and the
+agents read through these helpers instead of touching the dataclasses
+directly.
+
+CLI runs and any request that doesn't supply overrides just see the defaults.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Optional
+
+from backend.config import MODELS, THRESHOLDS, ModelAssignments
+
+NODE_NAMES = tuple(f.name for f in ModelAssignments.__dataclass_fields__.values())
+
+
+@dataclass(frozen=True)
+class RunOverrides:
+    """A single run's optional overrides.
+
+    ``model_override`` (when set) is applied to *every* AI node — useful for
+    switching the whole pipeline to a single model for a test run. Any field
+    set to ``None`` falls through to the corresponding default.
+    """
+
+    max_code_retries: Optional[int] = None
+    arxiv_results_per_round: Optional[int] = None
+    model_override: Optional[str] = None
+
+
+# ─── Thread-local binding ────────────────────────────────────────────────────
+_current = threading.local()
+
+
+def bind(overrides: Optional[RunOverrides]) -> None:
+    """Associate the calling thread with a set of overrides (or clear them)."""
+    if overrides is None:
+        clear()
+        return
+    _current.overrides = overrides
+
+
+def clear() -> None:
+    if hasattr(_current, "overrides"):
+        del _current.overrides
+
+
+def current() -> Optional[RunOverrides]:
+    return getattr(_current, "overrides", None)
+
+
+# ─── Read helpers used by the agents and graph router ───────────────────────
+def effective_max_code_retries() -> int:
+    o = current()
+    if o is not None and o.max_code_retries is not None:
+        return o.max_code_retries
+    return THRESHOLDS.max_code_retries
+
+
+def effective_arxiv_results_per_round() -> int:
+    o = current()
+    if o is not None and o.arxiv_results_per_round is not None:
+        return o.arxiv_results_per_round
+    return THRESHOLDS.arxiv_results_per_round
+
+
+def effective_model_for(node_name: str) -> str:
+    """Return the Anthropic model id to use for ``node_name``.
+
+    Falls back to the default mapping in :data:`backend.config.MODELS`. When a
+    run-wide ``model_override`` is bound it takes precedence for every node so
+    that "swap the whole pipeline to model X" is a one-line API request.
+    """
+    o = current()
+    if o is not None and o.model_override:
+        return o.model_override
+    if node_name not in NODE_NAMES:
+        raise KeyError(
+            f"Unknown model slot {node_name!r}; valid slots are {NODE_NAMES}"
+        )
+    return getattr(MODELS, node_name)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       SUPABASE_URL: ${SUPABASE_URL:-}
       SUPABASE_SERVICE_KEY: ${SUPABASE_SERVICE_KEY:-}
       HUGGINGFACE_TOKEN: ${HUGGINGFACE_TOKEN:-}
-      AUTO_MINI_CLAW_AUTO_APPROVE_HITL: "true"
+      AUTO_MINI_CLAW_HITL_MODE: "api"
       HOST_PROJECT_ROOT: ${PWD}
     volumes:
       - .:/app

--- a/src/components/GatePanel.jsx
+++ b/src/components/GatePanel.jsx
@@ -1,0 +1,356 @@
+import { useState } from "react";
+import { CheckCircle2, XCircle, AlertCircle, FileText, Network } from "lucide-react";
+
+/* ─── Helpers ─────────────────────────────────────────────────────────────── */
+
+function PolarityBadge({ polarity }) {
+  const styles = {
+    supports: "bg-emerald-500/15 text-emerald-300 ring-emerald-500/30",
+    contradicts: "bg-rose-500/15 text-rose-300 ring-rose-500/30",
+    neutral: "bg-white/5 text-text-muted ring-white/10",
+  };
+  return (
+    <span
+      className={`rounded-md px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide ring-1 ${
+        styles[polarity] || styles.neutral
+      }`}
+    >
+      {polarity}
+    </span>
+  );
+}
+
+function StatusPill({ ok, label }) {
+  return (
+    <span
+      className={`rounded-md px-2 py-0.5 text-[11px] font-semibold uppercase ring-1 ${
+        ok
+          ? "bg-emerald-500/15 text-emerald-300 ring-emerald-500/30"
+          : "bg-rose-500/15 text-rose-300 ring-rose-500/30"
+      }`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function SectionTitle({ icon: Icon, children }) {
+  return (
+    <div className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-text-secondary">
+      {Icon && <Icon size={14} strokeWidth={1.8} className="text-accent" />}
+      {children}
+    </div>
+  );
+}
+
+/* ─── Gate 1 — Hypothesis Approval ────────────────────────────────────────── */
+
+function HypothesisGateBody({ payload }) {
+  const { hypothesis, incremental_delta, novelty, prior_art, kg_triples, papers, paper_total } =
+    payload;
+  return (
+    <div className="space-y-5">
+      <section className="space-y-2">
+        <SectionTitle icon={FileText}>Generated Hypothesis</SectionTitle>
+        <p className="rounded-lg border border-white/8 bg-black/30 p-4 text-sm leading-relaxed text-text-primary">
+          {hypothesis}
+        </p>
+      </section>
+
+      <section className="space-y-2">
+        <SectionTitle>Incremental Delta (what&rsquo;s new)</SectionTitle>
+        <p className="rounded-lg border border-white/8 bg-black/30 p-4 text-sm leading-relaxed text-text-secondary">
+          {incremental_delta}
+        </p>
+      </section>
+
+      <section className="space-y-2">
+        <SectionTitle>Novelty Scores</SectionTitle>
+        <div className="overflow-hidden rounded-lg border border-white/8">
+          <table className="w-full text-sm">
+            <thead className="bg-white/5 text-left text-[11px] uppercase tracking-wide text-text-muted">
+              <tr>
+                <th className="px-3 py-2">Metric</th>
+                <th className="px-3 py-2">Value</th>
+                <th className="px-3 py-2">Threshold</th>
+                <th className="px-3 py-2">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/5">
+              <tr>
+                <td className="px-3 py-2 font-medium">Novelty (RND)</td>
+                <td className="px-3 py-2 font-mono">{novelty.score.toFixed(3)}</td>
+                <td className="px-3 py-2 font-mono text-text-muted">
+                  &ge; {novelty.threshold}
+                </td>
+                <td className="px-3 py-2">
+                  <StatusPill ok={novelty.pass} label={novelty.pass ? "Pass" : "Fail"} />
+                </td>
+              </tr>
+              <tr>
+                <td className="px-3 py-2 font-medium">Prior-Art Similarity</td>
+                <td className="px-3 py-2 font-mono">{prior_art.similarity.toFixed(3)}</td>
+                <td className="px-3 py-2 font-mono text-text-muted">
+                  &lt; {prior_art.ceiling}
+                </td>
+                <td className="px-3 py-2">
+                  <StatusPill ok={prior_art.pass} label={prior_art.pass ? "Pass" : "Fail"} />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {kg_triples.length > 0 && (
+        <section className="space-y-2">
+          <SectionTitle icon={Network}>Key KG Triples</SectionTitle>
+          <div className="overflow-hidden rounded-lg border border-white/8">
+            <table className="w-full text-sm">
+              <thead className="bg-white/5 text-left text-[11px] uppercase tracking-wide text-text-muted">
+                <tr>
+                  <th className="px-3 py-2">Source</th>
+                  <th className="px-3 py-2">Relation</th>
+                  <th className="px-3 py-2">Target</th>
+                  <th className="px-3 py-2">Polarity</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/5">
+                {kg_triples.map((edge, i) => (
+                  <tr key={i}>
+                    <td className="px-3 py-2">{edge.source}</td>
+                    <td className="px-3 py-2 font-mono text-text-secondary">{edge.relation}</td>
+                    <td className="px-3 py-2">{edge.target}</td>
+                    <td className="px-3 py-2">
+                      <PolarityBadge polarity={edge.polarity} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {papers.length > 0 && (
+        <section className="space-y-2">
+          <SectionTitle>Retrieved Papers ({paper_total})</SectionTitle>
+          <div className="overflow-hidden rounded-lg border border-white/8">
+            <table className="w-full text-sm">
+              <thead className="bg-white/5 text-left text-[11px] uppercase tracking-wide text-text-muted">
+                <tr>
+                  <th className="px-3 py-2">ArXiv ID</th>
+                  <th className="px-3 py-2">Title</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/5">
+                {papers.map((p, i) => (
+                  <tr key={i}>
+                    <td className="px-3 py-2 font-mono text-text-secondary">{p.arxiv_id}</td>
+                    <td className="px-3 py-2">{p.title}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+/* ─── Gate 2 — ExperimentSpec Approval ────────────────────────────────────── */
+
+function ExperimentGateBody({ payload }) {
+  const { hypothesis, incremental_delta, spec, kg_edges } = payload;
+  const specRows = [
+    ["Independent Variable", spec.independent_var],
+    ["Dependent Variable", spec.dependent_var],
+    ["Control Description", spec.control_description],
+    ["Dataset ID", spec.dataset_id],
+    ["Evaluation Metrics", spec.evaluation_metrics.join(", ")],
+    ["Expected Outcome", spec.expected_outcome],
+  ];
+  return (
+    <div className="space-y-5">
+      <section className="space-y-2">
+        <SectionTitle icon={FileText}>Hypothesis</SectionTitle>
+        <p className="rounded-lg border border-white/8 bg-black/30 p-4 text-sm leading-relaxed text-text-primary">
+          {hypothesis}
+        </p>
+      </section>
+
+      <section className="space-y-2">
+        <SectionTitle>Incremental Delta</SectionTitle>
+        <p className="rounded-lg border border-white/8 bg-black/30 p-4 text-sm leading-relaxed text-text-secondary">
+          {incremental_delta}
+        </p>
+      </section>
+
+      <section className="space-y-2">
+        <SectionTitle>Experiment Specification</SectionTitle>
+        <div className="overflow-hidden rounded-lg border border-white/8">
+          <table className="w-full text-sm">
+            <tbody className="divide-y divide-white/5">
+              {specRows.map(([field, value]) => (
+                <tr key={field}>
+                  <td className="w-56 bg-white/5 px-3 py-2 text-[12px] font-semibold uppercase tracking-wide text-text-secondary">
+                    {field}
+                  </td>
+                  <td className="px-3 py-2 text-text-primary">{value || "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {kg_edges.length > 0 && (
+        <section className="space-y-2">
+          <SectionTitle icon={Network}>Relevant KG Edges</SectionTitle>
+          <div className="overflow-hidden rounded-lg border border-white/8">
+            <table className="w-full text-sm">
+              <thead className="bg-white/5 text-left text-[11px] uppercase tracking-wide text-text-muted">
+                <tr>
+                  <th className="px-3 py-2">Source</th>
+                  <th className="px-3 py-2">Relation</th>
+                  <th className="px-3 py-2">Target</th>
+                  <th className="px-3 py-2">Polarity</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/5">
+                {kg_edges.map((edge, i) => (
+                  <tr key={i}>
+                    <td className="px-3 py-2">{edge.source}</td>
+                    <td className="px-3 py-2 font-mono text-text-secondary">{edge.relation}</td>
+                    <td className="px-3 py-2">{edge.target}</td>
+                    <td className="px-3 py-2">
+                      <PolarityBadge polarity={edge.polarity} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+/* ─── Outer panel ─────────────────────────────────────────────────────────── */
+
+const GATE_META = {
+  hypothesis: {
+    title: "HITL Gate 1 — Hypothesis Approval",
+    blurb:
+      "The pipeline has paused for your review. Approve to proceed to experiment design, or reject with a reason to regenerate.",
+    rejectPlaceholder:
+      "Why are you rejecting? Be specific — the feedback steers the regenerator (e.g. 'wrong model class', 'dataset not available offline').",
+  },
+  experiment: {
+    title: "HITL Gate 2 — Experiment Approval",
+    blurb:
+      "Review the ExperimentSpec before any code is written. Approve to run, reject for redesign, or type 'abort' as the reason to terminate.",
+    rejectPlaceholder:
+      "Reason (or type 'abort' to terminate the run instead of redesigning the experiment)",
+  },
+};
+
+export default function GatePanel({ gate, onSubmit, busy }) {
+  const [showReject, setShowReject] = useState(false);
+  const [reason, setReason] = useState("");
+  const meta = GATE_META[gate.gate_id] || {
+    title: `HITL Gate (${gate.gate_id})`,
+    blurb: "Awaiting decision.",
+    rejectPlaceholder: "Reason",
+  };
+
+  function approve() {
+    onSubmit({ action: "approve", reason: "" });
+  }
+  function reject() {
+    onSubmit({ action: "reject", reason: reason.trim() || "No reason provided" });
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-black/70 backdrop-blur-sm">
+      <div className="my-8 w-full max-w-4xl rounded-xl border border-accent/30 bg-bg-deep shadow-2xl">
+        <header className="flex items-start gap-3 border-b border-white/8 p-5">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-accent-dim ring-1 ring-accent/30">
+            <AlertCircle size={20} strokeWidth={1.8} className="text-accent" />
+          </div>
+          <div className="flex-1">
+            <h2 className="text-lg font-semibold text-text-primary">{meta.title}</h2>
+            <p className="mt-1 text-sm text-text-secondary">{meta.blurb}</p>
+          </div>
+        </header>
+
+        <div className="max-h-[60vh] overflow-y-auto p-5">
+          {gate.gate_id === "hypothesis" ? (
+            <HypothesisGateBody payload={gate.payload} />
+          ) : (
+            <ExperimentGateBody payload={gate.payload} />
+          )}
+        </div>
+
+        <footer className="space-y-3 border-t border-white/8 p-5">
+          {showReject && (
+            <textarea
+              autoFocus
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              rows={3}
+              placeholder={meta.rejectPlaceholder}
+              className="w-full resize-none rounded-lg border border-white/10 bg-black/40 p-3 text-sm text-text-primary placeholder:text-text-muted focus:border-accent/60 focus:outline-none"
+            />
+          )}
+          <div className="flex flex-wrap justify-end gap-2">
+            {!showReject ? (
+              <>
+                <button
+                  type="button"
+                  onClick={() => setShowReject(true)}
+                  disabled={busy}
+                  className="inline-flex items-center gap-2 rounded-lg border border-rose-500/40 bg-rose-500/10 px-4 py-2 text-sm font-medium text-rose-200 transition hover:bg-rose-500/20 disabled:opacity-50"
+                >
+                  <XCircle size={16} strokeWidth={1.8} /> Reject
+                </button>
+                <button
+                  type="button"
+                  onClick={approve}
+                  disabled={busy}
+                  className="inline-flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-black transition hover:bg-accent/90 disabled:opacity-50"
+                >
+                  <CheckCircle2 size={16} strokeWidth={1.8} /> Approve
+                </button>
+              </>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowReject(false);
+                    setReason("");
+                  }}
+                  disabled={busy}
+                  className="rounded-lg border border-white/10 bg-black/30 px-4 py-2 text-sm text-text-secondary transition hover:bg-black/50 disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={reject}
+                  disabled={busy}
+                  className="inline-flex items-center gap-2 rounded-lg bg-rose-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-rose-500/90 disabled:opacity-50"
+                >
+                  <XCircle size={16} strokeWidth={1.8} /> Confirm Reject
+                </button>
+              </>
+            )}
+          </div>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/components/RunArtifacts.jsx
+++ b/src/components/RunArtifacts.jsx
@@ -1,0 +1,211 @@
+import { useEffect, useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Download,
+  FileText,
+  RefreshCw,
+} from "lucide-react";
+import { artifactDownloadUrl, listArtifacts } from "../services/api";
+
+/* Human-readable labels for each artifact the uploader produces. */
+const FILE_LABELS = {
+  "final_paper.pdf":      "Compiled paper (NeurIPS-formatted PDF)",
+  "draft.tex":            "LaTeX source the compiler ran",
+  "references.bib":       "BibTeX references cited in the paper",
+  "metrics.json":         "Experiment metrics and hyperparameters",
+  "claim_ledger.json":    "Every paper claim mapped to KG evidence",
+  "debate_log.json":      "Critique panel debate log (challenges + retractions)",
+  "python_code.py":       "The script the ML Coder generated and the sandbox ran",
+  "execution_logs.txt":   "Full sandbox stdout/stderr",
+  "hypothesis.txt":       "The hypothesis the run was testing",
+  "experiment_spec.json": "ExperimentSpec — IV, DV, dataset, metrics",
+  "failure_report.json":  "Terminal status, retry counts, last 4KB of logs",
+};
+
+/* Recommended display order, per variant. */
+const PRIORITY = {
+  success: [
+    "final_paper.pdf",
+    "draft.tex",
+    "references.bib",
+    "metrics.json",
+    "claim_ledger.json",
+    "debate_log.json",
+    "python_code.py",
+    "execution_logs.txt",
+    "hypothesis.txt",
+    "experiment_spec.json",
+    "failure_report.json",
+  ],
+  failure: [
+    "failure_report.json",
+    "execution_logs.txt",
+    "python_code.py",
+    "hypothesis.txt",
+    "experiment_spec.json",
+    "metrics.json",
+    "claim_ledger.json",
+    "debate_log.json",
+    "draft.tex",
+    "references.bib",
+    "final_paper.pdf",
+  ],
+};
+
+/* Per-variant chrome: colours, icon, default title, default intro. */
+const VARIANT_STYLES = {
+  success: {
+    Icon: CheckCircle2,
+    panel: "border-emerald-500/30 bg-emerald-500/5",
+    headerBorder: "border-emerald-500/20",
+    iconWrap: "bg-emerald-500/15 ring-emerald-500/30",
+    iconText: "text-emerald-300",
+    title: "Run complete — download paper & artifacts",
+    intro:
+      "The pipeline finished. The compiled PDF, LaTeX source, metrics, and supporting evidence are below.",
+  },
+  failure: {
+    Icon: AlertTriangle,
+    panel: "border-rose-500/30 bg-rose-500/5",
+    headerBorder: "border-rose-500/20",
+    iconWrap: "bg-rose-500/15 ring-rose-500/30",
+    iconText: "text-rose-300",
+    title: "Run failed — download diagnostics",
+    intro:
+      "The pipeline terminated before producing a paper. The files below are everything the uploader managed to persist for this run.",
+  },
+};
+
+function sortByPriority(names, variant) {
+  const order = new Map(PRIORITY[variant].map((n, i) => [n, i]));
+  return [...names].sort(
+    (a, b) => (order.get(a) ?? 999) - (order.get(b) ?? 999),
+  );
+}
+
+export default function RunArtifacts({ runId, variant = "success", error }) {
+  const [files, setFiles] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(null);
+
+  const styles = VARIANT_STYLES[variant] || VARIANT_STYLES.success;
+  const { Icon } = styles;
+
+  const refresh = () => {
+    if (!runId) return;
+    setLoading(true);
+    setLoadError(null);
+    listArtifacts(runId)
+      .then((r) => setFiles(sortByPriority(r.files || [], variant)))
+      .catch((e) => setLoadError(e.message || "Failed to list artifacts"))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runId, variant]);
+
+  if (!runId) return null;
+
+  return (
+    <div className={`panel-raised mt-4 rounded-lg border ${styles.panel}`}>
+      <header className={`flex items-start gap-3 border-b ${styles.headerBorder} p-5`}>
+        <div
+          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ring-1 ${styles.iconWrap}`}
+        >
+          <Icon size={20} strokeWidth={1.8} className={styles.iconText} />
+        </div>
+        <div className="flex-1">
+          <h3 className="text-base font-semibold text-text-primary">
+            {styles.title}
+          </h3>
+          <p className="mt-1 text-sm text-text-secondary">
+            {error || styles.intro}
+          </p>
+          <p className="mt-1 text-[11px] font-mono text-text-muted">
+            run_id: {runId}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={refresh}
+          className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-white/10 bg-black/30 text-text-secondary transition hover:bg-black/50"
+          title="Refresh artifact list"
+        >
+          <RefreshCw
+            size={14}
+            strokeWidth={1.8}
+            className={loading ? "animate-spin" : ""}
+          />
+        </button>
+      </header>
+
+      <div className="p-5">
+        {loadError && (
+          <p className="rounded-md border border-rose-500/30 bg-rose-500/10 p-3 text-sm text-rose-200">
+            {loadError}
+          </p>
+        )}
+
+        {!loadError && !loading && files.length === 0 && (
+          <p className="text-sm text-text-muted">
+            No artifacts were uploaded for this run. The pipeline likely
+            crashed before reaching the upload step.
+          </p>
+        )}
+
+        {files.length > 0 && (
+          <ul className="space-y-2">
+            {files.map((name, idx) => {
+              // Highlight the most useful download for each variant: the PDF
+              // on success, the failure report on failure.
+              const isPrimary = idx === 0;
+              return (
+                <li
+                  key={name}
+                  className={`flex items-center gap-3 rounded-lg border p-3 ${
+                    isPrimary
+                      ? "border-accent/30 bg-accent/5"
+                      : "border-white/8 bg-black/20"
+                  }`}
+                >
+                  <FileText
+                    size={16}
+                    strokeWidth={1.8}
+                    className={`shrink-0 ${
+                      isPrimary ? "text-accent" : "text-text-secondary"
+                    }`}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate font-mono text-sm text-text-primary">
+                      {name}
+                    </p>
+                    {FILE_LABELS[name] && (
+                      <p className="mt-0.5 text-[12px] text-text-muted">
+                        {FILE_LABELS[name]}
+                      </p>
+                    )}
+                  </div>
+                  <a
+                    href={artifactDownloadUrl(runId, name)}
+                    download={name}
+                    className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-semibold ring-1 transition ${
+                      isPrimary
+                        ? "bg-accent text-black ring-accent hover:brightness-110"
+                        : "bg-accent/20 text-accent ring-accent/30 hover:bg-accent/30"
+                    }`}
+                  >
+                    <Download size={13} strokeWidth={2} />
+                    Download
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/context/PipelineContext.jsx
+++ b/src/context/PipelineContext.jsx
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { pipelineStages } from "../data/pipelineStages";
-import { createPipelineRun, getPipelineRun } from "../services/api";
+import {
+  createPipelineRun,
+  getPipelineRun,
+  getPendingGate,
+  submitGateDecision,
+} from "../services/api";
 import { PipelineContext } from "./pipelineContextObject";
 
 const seedLogs = [
@@ -49,8 +54,18 @@ export function PipelineProvider({ children }) {
   const [backendStatus, setBackendStatus] = useState("idle");
   const [backendError, setBackendError] = useState(null);
   const [backendResult, setBackendResult] = useState(null);
+  const [pendingGate, setPendingGate] = useState(null);
+  const [gateBusy, setGateBusy] = useState(false);
+  // Tracks which HITL gates have already been decided (approved or rejected)
+  // for the current run. The visual pipeline blocks at the corresponding
+  // stage until the matching gate is decided, so the animation reflects the
+  // real backend pause instead of racing ahead on a scripted timer.
+  const [gatesDecided, setGatesDecided] = useState({
+    hypothesis: false,
+    experiment: false,
+  });
 
-  const startRun = (nextTopic) => {
+  const startRun = (nextTopic, overrides = {}) => {
     const trimmed = nextTopic.trim();
     if (!trimmed) return;
 
@@ -61,6 +76,8 @@ export function PipelineProvider({ children }) {
     setBackendStatus("queued");
     setBackendError(null);
     setBackendResult(null);
+    setPendingGate(null);
+    setGatesDecided({ hypothesis: false, experiment: false });
     const startTime = Date.now();
     setStartedAt(startTime);
     setElapsedSeconds(0);
@@ -75,7 +92,7 @@ export function PipelineProvider({ children }) {
       ...makeStageLog(firstStage, trimmed, 0),
     ]);
 
-    createPipelineRun(trimmed)
+    createPipelineRun(trimmed, overrides)
       .then((record) => {
         setBackendRunId(record.client_run_id);
         setBackendStatus(record.status);
@@ -113,6 +130,13 @@ export function PipelineProvider({ children }) {
       return undefined;
     }
 
+    // Block the auto-advance at the two HITL gate stages so the visual
+    // pipeline doesn't race past a backend that is still waiting for an
+    // approve/reject decision. Stage 2 ("hypothesis") gates on Gate 1,
+    // stage 3 ("design") gates on Gate 2.
+    if (activeStageIndex === 2 && !gatesDecided.hypothesis) return undefined;
+    if (activeStageIndex === 3 && !gatesDecided.experiment) return undefined;
+
     const timer = window.setTimeout(() => {
       const nextIndex = activeStageIndex + 1;
       setActiveStageIndex(nextIndex);
@@ -149,7 +173,15 @@ export function PipelineProvider({ children }) {
     }, stage.duration);
 
     return () => window.clearTimeout(timer);
-  }, [activeStageIndex, backendRunId, backendStatus, isRunning, topic]);
+  }, [
+    activeStageIndex,
+    backendRunId,
+    backendStatus,
+    gatesDecided.hypothesis,
+    gatesDecided.experiment,
+    isRunning,
+    topic,
+  ]);
 
   useEffect(() => {
     if (!isRunning || !startedAt) return undefined;
@@ -217,6 +249,88 @@ export function PipelineProvider({ children }) {
     return () => window.clearInterval(poll);
   }, [backendRunId, backendStatus]);
 
+  // ─── Poll for pending HITL gates while a run is active ───────────────────
+  useEffect(() => {
+    if (!backendRunId) return undefined;
+    if (backendStatus === "success" || backendStatus === "failed") return undefined;
+
+    const tick = () => {
+      getPendingGate(backendRunId)
+        .then((snapshot) => {
+          if (snapshot?.pending) {
+            setPendingGate((current) => {
+              if (current && current.gate_id === snapshot.gate_id) {
+                return current;
+              }
+              return {
+                gate_id: snapshot.gate_id,
+                run_id: snapshot.run_id,
+                payload: snapshot.payload,
+              };
+            });
+            // Snap the visual pipeline to the gate's stage so the user
+            // sees that we are paused *at* that node, not somewhere later.
+            const gateStageIndex =
+              snapshot.gate_id === "hypothesis" ? 2 : 3;
+            setActiveStageIndex((current) =>
+              current < gateStageIndex ? gateStageIndex : current,
+            );
+          } else {
+            setPendingGate(null);
+          }
+        })
+        .catch(() => {
+          /* transient — next tick retries */
+        });
+    };
+
+    tick();
+    const poll = window.setInterval(tick, 2000);
+    return () => window.clearInterval(poll);
+  }, [backendRunId, backendStatus]);
+
+  const submitGate = ({ action, reason }) => {
+    if (!backendRunId || !pendingGate) return Promise.resolve();
+    const decidedGateId = pendingGate.gate_id;
+    setGateBusy(true);
+    return submitGateDecision(backendRunId, {
+      gateId: decidedGateId,
+      action,
+      reason,
+    })
+      .then(() => {
+        // Unblock the visual pipeline past this gate.
+        setGatesDecided((current) => ({ ...current, [decidedGateId]: true }));
+        setLogs((current) => [
+          ...current,
+          {
+            time: stamp(),
+            level: action === "approve" ? "success" : "warn",
+            agent: pendingGate.gate_id === "hypothesis" ? "hitl_gate" : "hitl_experiment_gate",
+            msg:
+              action === "approve"
+                ? `Gate ${pendingGate.gate_id} approved.`
+                : `Gate ${pendingGate.gate_id} rejected: ${reason}`,
+          },
+        ]);
+        setPendingGate(null);
+      })
+      .catch((error) => {
+        setLogs((current) => [
+          ...current,
+          {
+            time: stamp(),
+            level: "error",
+            agent: "api",
+            msg: `Gate decision failed: ${error.message}`,
+          },
+        ]);
+      })
+      .finally(() => {
+        setGateBusy(false);
+      });
+  };
+
   const stageStates = useMemo(() => {
     return pipelineStages.reduce((states, stage, index) => {
       let status = "idle";
@@ -248,6 +362,9 @@ export function PipelineProvider({ children }) {
     progress,
     stageStates,
     startRun,
+    pendingGate,
+    submitGate,
+    gateBusy,
   };
 
   return (

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -12,8 +12,10 @@ import {
 } from "lucide-react";
 import AgentTimeline from "../components/AgentTimeline";
 import ArtifactDock from "../components/ArtifactDock";
+import GatePanel from "../components/GatePanel";
 import LogPanel from "../components/LogPanel";
 import PaperPreview from "../components/PaperPreview";
+import RunArtifacts from "../components/RunArtifacts";
 import StatCard from "../components/StatCard";
 import { usePipeline } from "../context/usePipeline";
 import { pipelineStages } from "../data/pipelineStages";
@@ -26,9 +28,12 @@ export default function Dashboard() {
     backendRunId,
     backendStatus,
     elapsedSeconds,
+    gateBusy,
     isRunning,
     logs,
+    pendingGate,
     progress,
+    submitGate,
     topic,
   } = usePipeline();
 
@@ -121,6 +126,16 @@ export default function Dashboard() {
                 style={{ width: `${progress}%` }}
               />
             </div>
+            {backendStatus === "success" && backendRunId && (
+              <RunArtifacts runId={backendRunId} variant="success" />
+            )}
+            {backendStatus === "failed" && backendRunId && (
+              <RunArtifacts
+                runId={backendRunId}
+                variant="failure"
+                error={backendError}
+              />
+            )}
           </div>
         </div>
         <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
@@ -214,6 +229,13 @@ export default function Dashboard() {
         activeStageIndex={activeStageIndex}
         isRunning={isRunning}
       />
+      {pendingGate && (
+        <GatePanel
+          gate={pendingGate}
+          onSubmit={submitGate}
+          busy={gateBusy}
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/NewResearch.jsx
+++ b/src/pages/NewResearch.jsx
@@ -26,16 +26,18 @@ export default function NewResearch() {
   const navigate = useNavigate();
   const { startRun } = usePipeline();
   const [config, setConfig] = useState({
-    researcherModel: "haiku",
-    coderModel: "sonnet",
-    writerModel: "sonnet",
+    modelOverride: "",  // empty = use per-node defaults from backend/config.py
     maxRetries: 3,
     maxPapers: 5,
   });
 
   const launch = () => {
     if (!topic.trim()) return;
-    startRun(topic);
+    startRun(topic, {
+      modelOverride: config.modelOverride || null,
+      maxCodeRetries: config.maxRetries,
+      arxivResultsPerRound: config.maxPapers,
+    });
     navigate("/");
   };
 
@@ -113,65 +115,68 @@ export default function NewResearch() {
         </button>
 
         {showAdvanced && (
-          <div className="grid gap-4 animate-slide-in sm:grid-cols-2">
-            {[
-              { key: "researcherModel", label: "Researcher Model" },
-              { key: "coderModel", label: "Coder Model" },
-              { key: "writerModel", label: "Writer Model" },
-            ].map(({ key, label }) => (
-              <div key={key} className="space-y-1.5">
-                <label className="text-xs font-medium text-text-muted">
-                  {label}
-                </label>
-                <select
-                  value={config[key]}
-                  onChange={(e) =>
-                    setConfig((c) => ({ ...c, [key]: e.target.value }))
-                  }
-                  className="w-full cursor-pointer appearance-none rounded-lg border border-border bg-black/10 px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:outline-none"
-                >
-                  <option value="haiku">Claude 3.5 Haiku</option>
-                  <option value="sonnet">Claude 3.7 Sonnet</option>
-                </select>
-              </div>
-            ))}
-
-            <div className="space-y-1.5">
+          <div className="animate-slide-in space-y-4">
+            <div className="space-y-1.5 sm:col-span-2">
               <label className="text-xs font-medium text-text-muted">
-                Max Retries
+                Model Override (applies to every AI node)
               </label>
-              <input
-                type="number"
-                min={1}
-                max={5}
-                value={config.maxRetries}
+              <select
+                value={config.modelOverride}
                 onChange={(e) =>
-                  setConfig((c) => ({
-                    ...c,
-                    maxRetries: parseInt(e.target.value) || 3,
-                  }))
+                  setConfig((c) => ({ ...c, modelOverride: e.target.value }))
                 }
-                className="w-full rounded-lg border border-border bg-black/10 px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:outline-none"
-              />
+                className="w-full cursor-pointer appearance-none rounded-lg border border-border bg-black/10 px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:outline-none"
+              >
+                <option value="">Use per-node defaults (recommended)</option>
+                <option value="claude-haiku-4-5-20251001">claude-haiku-4-5 &mdash; cheap, fast (every node)</option>
+                <option value="claude-sonnet-4-6">claude-sonnet-4-6 &mdash; strongest (every node)</option>
+                <option value="claude-opus-4-7">claude-opus-4-7 &mdash; max quality, slow + expensive</option>
+              </select>
+              <p className="text-[11px] text-text-muted">
+                Defaults pick Haiku for cheap structured tasks (KG extraction,
+                LaTeX repair) and Sonnet for reasoning (hypothesis, coding,
+                writing). Overriding swaps the whole pipeline to one model.
+              </p>
             </div>
 
-            <div className="space-y-1.5">
-              <label className="text-xs font-medium text-text-muted">
-                Max Papers to Fetch
-              </label>
-              <input
-                type="number"
-                min={1}
-                max={20}
-                value={config.maxPapers}
-                onChange={(e) =>
-                  setConfig((c) => ({
-                    ...c,
-                    maxPapers: parseInt(e.target.value) || 5,
-                  }))
-                }
-                className="w-full rounded-lg border border-border bg-black/10 px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:outline-none"
-              />
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-text-muted">
+                  Max Code Retries (sandbox self-heal loop)
+                </label>
+                <input
+                  type="number"
+                  min={0}
+                  max={10}
+                  value={config.maxRetries}
+                  onChange={(e) =>
+                    setConfig((c) => ({
+                      ...c,
+                      maxRetries: parseInt(e.target.value, 10) || 0,
+                    }))
+                  }
+                  className="w-full rounded-lg border border-border bg-black/10 px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:outline-none"
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-text-muted">
+                  Max Papers per ArXiv Round
+                </label>
+                <input
+                  type="number"
+                  min={1}
+                  max={50}
+                  value={config.maxPapers}
+                  onChange={(e) =>
+                    setConfig((c) => ({
+                      ...c,
+                      maxPapers: parseInt(e.target.value, 10) || 5,
+                    }))
+                  }
+                  className="w-full rounded-lg border border-border bg-black/10 px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:outline-none"
+                />
+              </div>
             </div>
           </div>
         )}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -17,13 +17,45 @@ async function request(path, options = {}) {
   return response.json();
 }
 
-export function createPipelineRun(topic) {
+export function createPipelineRun(topic, overrides = {}) {
+  // Strip null/undefined/empty so the server only sees explicit overrides.
+  const body = { topic };
+  if (overrides.maxCodeRetries != null && overrides.maxCodeRetries !== "") {
+    body.max_code_retries = Number(overrides.maxCodeRetries);
+  }
+  if (overrides.arxivResultsPerRound != null && overrides.arxivResultsPerRound !== "") {
+    body.arxiv_results_per_round = Number(overrides.arxivResultsPerRound);
+  }
+  if (overrides.modelOverride) {
+    body.model_override = overrides.modelOverride;
+  }
   return request("/runs", {
     method: "POST",
-    body: JSON.stringify({ topic }),
+    body: JSON.stringify(body),
   });
 }
 
 export function getPipelineRun(runId) {
   return request(`/runs/${runId}`);
+}
+
+export function getPendingGate(runId) {
+  return request(`/runs/${runId}/pending-gate`);
+}
+
+export function submitGateDecision(runId, { gateId, action, reason = "" }) {
+  return request(`/runs/${runId}/gate-decision`, {
+    method: "POST",
+    body: JSON.stringify({ gate_id: gateId, action, reason }),
+  });
+}
+
+export function listArtifacts(runId) {
+  return request(`/runs/${runId}/artifacts`);
+}
+
+// URL the browser can hit directly via <a download> to trigger a file save.
+// Goes through the same Vite/nginx /api proxy as the rest of the calls.
+export function artifactDownloadUrl(runId, filename) {
+  return `${API_BASE_URL}/runs/${runId}/artifacts/${encodeURIComponent(filename)}`;
 }


### PR DESCRIPTION
## Summary
- Backend HITL bridge (thread-local + threading.Event) so the React UI drives both gates
- Per-run model + threshold overrides plumbed through to the agents
- Artifact list / download endpoints + success & failure download panels
- Unified API run_id with pipeline_runs.id and the storage folder (was 2 separate UUIDs)
- .dockerignore venv exclusion: build context 5.58 GB → 870 KB

## Test plan
- [x] docker compose up --build -d brings both services up
- [x] New run pauses at HITL Gate 1; modal renders hypothesis + KG triples
- [x] Approve/reject Gate 1, then Gate 2; pipeline proceeds correctly
- [x] On success, RunArtifacts panel offers final_paper.pdf as primary download
- [x] On failure, RunArtifacts panel offers failure_report.json as primary download